### PR TITLE
Fetch ad assets from The Graph

### DIFF
--- a/aframe/.gitignore
+++ b/aframe/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/aframe/index.html
+++ b/aframe/index.html
@@ -27,8 +27,7 @@
       <a-box color="tomato" depth="4" height="4" width="0.5" position="2.5 2 2"></a-box>
 
       <!-- Our ads -->
-      <a-entity visible="true" zesty-ad="auId: ce6f68fc-4809-4409-8f57-c631283ce5a3" position="0 2 0"></a-entity>
-      <a-zesty-ad visible="true" position="4 2 0"></a-zesty-ad>
+      <a-entity visible="true" zesty-ad="tokenGroup: 0; publisher: 0xC22F22d096D578148FFDbe969E89b0fe5Cb9d5aB" position="0 2 0"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/aframe/package.json
+++ b/aframe/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "aframe": "^0.9.2",
     "aframe-extras": "^6.0.0",
+    "axios": "^0.21.1",
     "uuid": "^3.3.3"
   },
   "devDependencies": {

--- a/aframe/src/index-wle.js
+++ b/aframe/src/index-wle.js
@@ -1,6 +1,7 @@
-import { fetchAd, sendMetric } from './networking';
+import { fetchNFT, fetchActiveAd, sendMetric } from './networking';
 
 window.Zesty = {
-    fetchAd: fetchAd,
+    fetchNFT: fetchNFT,
+    fetchActiveAd: fetchActiveAd,
     sendMetric: sendMetric
 };

--- a/aframe/src/index.js
+++ b/aframe/src/index.js
@@ -25,9 +25,9 @@ AFRAME.registerComponent('zesty-ad', {
       }
     }
     
-    // if (!!component.getAttribute('visible') && !component.firstChild) {
-    //   this.init();
-    // }
+    if (!!component.getAttribute('visible') && !component.firstChild) {
+      this.init();
+    }
   },
 
   remove: function() {
@@ -122,10 +122,6 @@ AFRAME.registerSystem('zesty-ad', {
 
     if (!el.hasAttribute('visibility-check')) {
       el.setAttribute('visibility-check', '');
-    }
-
-    if (!el.hasAttribute('zesty-clickable')) {
-      el.setAttribute('zesty-clickable', '');
     }
 
     this.entities.push(el);

--- a/aframe/src/logger.js
+++ b/aframe/src/logger.js
@@ -1,4 +1,4 @@
-const debug = false;
+const debug = true;
 
 export function log(message) {
     if (debug) {

--- a/aframe/src/logger.js
+++ b/aframe/src/logger.js
@@ -1,4 +1,4 @@
-const debug = true;
+const debug = false;
 
 export function log(message) {
     if (debug) {

--- a/aframe/src/networking.js
+++ b/aframe/src/networking.js
@@ -13,9 +13,8 @@ const METRICS_ENDPOINT = null;
 
 const sessionId = uuidv4();
 
-const fetchAd = async (tokenGroup, publisher) => {
+const fetchNFT = async (tokenGroup, publisher) => {
   const currentTime = Math.floor(Date.now() / 1000);
-
   return axios.post(AD_ENDPOINT, {
     query: `
       query {
@@ -44,16 +43,14 @@ const fetchAd = async (tokenGroup, publisher) => {
   .then((res) => {
     return res.status == 200 ? res.data : null
   })
-  .then((data) => {
-    const uri = data.data.adDatas[0].uri
-    
-    // fetch ad asset data
-    return axios.get(uri)
-    .then((res) => {
-      return res.status == 200 ? { uri: uri, data: res.data } : null
-    })
-  });
 };
+
+const fetchActiveAd = async (uri) => {
+  return axios.get(uri)
+  .then((res) => {
+    return res.status == 200 ? { uri: uri, data: res.data } : null
+  })
+}
 
 // TODO
 const sendMetric = (event, duration, adId, auId) => {
@@ -85,4 +82,4 @@ const sendMetric = (event, duration, adId, auId) => {
   });
 };
 
-export { fetchAd, sendMetric };
+export { fetchNFT, fetchActiveAd, sendMetric };

--- a/aframe/src/visibility_check.js
+++ b/aframe/src/visibility_check.js
@@ -95,12 +95,15 @@ AFRAME.registerComponent('visibility-check', {
         // is not enough because we could miss out on events e.g. if a game is turned off
         // without triggering isVisible=false.
         const duration = new Date().getTime() - this.lastVisible;
-        sendMetric(
-          'gaze', // event
-          duration, // duration
-          this.el.adId, // adId
-          this.el.auId, // auId
-        );
+
+        // TODO
+        // sendMetric(
+        //   'gaze', // event
+        //   duration, // duration
+        //   this.el.adId, // adId
+        //   this.el.auId, // auId
+        // );
+
         log(`${this.object.id} - Gaze for ${duration}ms`);
         this.lastVisible = null;
       }

--- a/aframe/yarn.lock
+++ b/aframe/yarn.lock
@@ -421,6 +421,13 @@ axios@0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1134,7 +1141,7 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-"debug@github:ngokevin/debug#noTimestamp":
+debug@ngokevin/debug#noTimestamp:
   version "2.2.0"
   resolved "https://codeload.github.com/ngokevin/debug/tar.gz/ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
 
@@ -1301,7 +1308,7 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-"document-register-element@github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90":
+document-register-element@dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90:
   version "0.5.4"
   resolved "https://codeload.github.com/dmarcos/document-register-element/tar.gz/8ccc532b7f3744be954574caf3072a5fd260ca90"
 
@@ -1775,7 +1782,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
   integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==


### PR DESCRIPTION
Each publisher will have a unique set of NFTs that represent their own digital spaces. After an advertiser has purchased a time-share of the digital space, they will be able to set a JSON file that provides information about the advertisement - this JSON file looks like:

```json
{
    "name": "Default Ad",
    "description": "This is the default ad that would be displayed ipsum",
    "image": "https://cdn.discordapp.com/attachments/798971482880737330/798974446349582356/Zesty_Market.png",
    "properties": {
      "cta": "https://zesty.market"
    }
}
```

(The above JSON can have its own `id`)

The above data contains the image and the CTA that will be specified for advertisers for display on the Zesty Network, and will be indexed by The Graph on a regular basis. This PR adds functionality for our A-Frame SDK to be able to fetch this data from The Graph and display it within the A-Frame environment.