### PR TITLE
Parse protocol

### DIFF
--- a/aframe/src/index.js
+++ b/aframe/src/index.js
@@ -1,6 +1,6 @@
 import { fetchNFT, fetchActiveBanner, sendMetric } from '../../utils/networking';
 import { formats, defaultFormat, defaultStyle } from '../../utils/formats';
-import { parseIPFS } from '../../utils/helpers';
+import { parseProtocol } from '../../utils/helpers';
 import { log } from './logger';
 import './visibility_check';
 
@@ -103,7 +103,7 @@ async function loadBanner(space, creator, network, format, style) {
   url = url.match(/^http[s]?:\/\//) ? url : 'https://' + url;
 
   let image = activeBanner.data.image;
-  image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseIPFS(image);
+  image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseProtocol(image);
 
   const img = document.createElement('img');
   img.setAttribute('id', activeBanner.uri)

--- a/babylonjs/src/index.js
+++ b/babylonjs/src/index.js
@@ -1,6 +1,6 @@
 import { fetchNFT, fetchActiveBanner, sendMetric } from '../../utils/networking';
 import { formats, defaultFormat } from '../../utils/formats';
-import { parseIPFS } from '../../utils/helpers';
+import { parseProtocol } from '../../utils/helpers';
 //import * as BABYLON from 'babylonjs';
 
 export default class ZestyBanner {
@@ -49,7 +49,7 @@ async function loadBanner(space, creator, network, format, style) {
   }
 
   let image = activeBanner.data.image;
-  image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseIPFS(image);
+  image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseProtocol(image);
 
   const mat = new BABYLON.StandardMaterial('');
   mat.diffuseTexture = new BABYLON.Texture(image);

--- a/r3f/src/ZestyBanner.js
+++ b/r3f/src/ZestyBanner.js
@@ -4,7 +4,7 @@ import { useRef, useState, Suspense, useEffect } from "react"
 import { fetchNFT, fetchActiveBanner, sendMetric } from "../../utils/networking"
 import { formats, defaultFormat } from '../../utils/formats';
 import { Interactive } from '@react-three/xr'
-import { parseIPFS } from '../../utils/helpers';
+import { parseProtocol } from '../../utils/helpers';
 
 export default function ZestyBanner(props) {
   const [bannerData, setBannerData] = useState(false)
@@ -26,7 +26,7 @@ export default function ZestyBanner(props) {
       if (url == 'https://www.zesty.market') {
         url = `https://app.zesty.market/space/${props.space}`;
       }
-      banner.image = banner.image.match(/^.+\.(png|jpe?g)/i) ? banner.image : parseIPFS(banner.image);
+      banner.image = banner.image.match(/^.+\.(png|jpe?g)/i) ? banner.image : parseProtocol(banner.image);
       sendMetric(
         props.creator,
         space,

--- a/threejs/src/index.js
+++ b/threejs/src/index.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { fetchNFT, fetchActiveBanner, sendMetric } from '../../utils/networking'
 import { formats, defaultFormat } from '../../utils/formats';
-import { parseIPFS } from '../../utils/helpers';
+import { parseProtocol } from '../../utils/helpers';
 
 export default class ZestyBanner extends THREE.Mesh {
   /**
@@ -78,7 +78,7 @@ async function loadBanner(space, creator, network, format, style) {
   }
 
   let image = activeBanner.data.image;
-  image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseIPFS(image);
+  image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseProtocol(image);
 
   return new Promise((resolve, reject) => {
     const loader = new THREE.TextureLoader();

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,12 +1,26 @@
+import axios from 'axios';
 /**
- * Parses ipfs:// links and IPFS hashes to URLs.
+ * Parses ipfs:// and ar:// links and IPFS hashes to URLs.
  * @param {String} uri The ipfs:// link or IPFS hash.
  * @returns A formatted URL to the IPFS resource.
  */
-const parseIPFS = uri => {
-    return uri.substring(0,4) === "ipfs" ? 
-    `https://ipfs.zesty.market/ipfs/${uri.substring(7)}` :
-    `https://ipfs.zesty.market/ipfs/${uri}`;
+const parseProtocol = uri => {
+  if (uri.substring(0,4) === "ipfs") {
+    return `https://ipfs.zesty.market/ipfs/${uri.substring(7)}`;
+  } else if (uri.substring(0,2) === "ar") {
+    // get redirected url
+    axios.get(`https://arweave.net/${uri.substring(5)}`)
+      .then(res => {
+        return res.url;
+      })
+      .catch(err => {
+        console.error(err);
+      })
+
+  } else {
+    // default to ipfs
+    return `https://ipfs.zesty.market/ipfs/${uri}`;
+  }
 }
 
-export { parseIPFS }
+export { parseProtocol };

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -7,6 +7,10 @@ import axios from 'axios';
 const parseProtocol = uri => {
   if (uri.substring(0,4) === "ipfs") {
     return `https://ipfs.zesty.market/ipfs/${uri.substring(7)}`;
+  } else if (uri.substring(0,4) === "http") {
+    return uri;
+  } else if (uri.substring(0,5) === "https") {
+    return uri;
   } else if (uri.substring(0,2) === "ar") {
     // get redirected url
     axios.get(`https://arweave.net/${uri.substring(5)}`)

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { formats, defaultFormat, defaultStyle } from '../utils/formats';
+import { parseProtocol } from '../utils/helpers';
 //import { v4 as uuidv4 } from 'uuid'
 
 // Modify to test a local server
@@ -107,7 +108,7 @@ const fetchActiveBanner = async (uri, format, style) => {
     return bannerObject;
   }
 
-  return axios.get(`https://ipfs.zesty.market/ipfs/${uri}`)
+  return axios.get(parseProtocol(uri))
   .then((res) => {
     return res.status == 200 ? { uri: uri, data: res.data } : null
   })

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,6 +1,6 @@
 import { fetchNFT, fetchActiveBanner } from '../../utils/networking'
 import { formats, defaultFormat, defaultStyle } from '../../utils/formats';
-import { parseIPFS } from '../../utils/helpers';
+import { parseProtocol } from '../../utils/helpers';
 
 class Zesty extends HTMLElement {
     constructor() {
@@ -45,7 +45,7 @@ class Zesty extends HTMLElement {
             }
 
             let image = activeBanner.data.image;
-            image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseIPFS(image);
+            image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseProtocol(image);
 
             const img = document.createElement('img');
             shadow.appendChild(img)

--- a/wonderland/src/index.js
+++ b/wonderland/src/index.js
@@ -1,6 +1,6 @@
 import { fetchNFT, fetchActiveBanner, sendMetric } from '../../utils/networking'
 import { formats, defaultFormat } from '../../utils/formats';
-import { parseIPFS } from '../../utils/helpers';
+import { parseProtocol } from '../../utils/helpers';
 
 /**
  * [Zesty Market](https://zesty.market) banner space
@@ -108,7 +108,7 @@ WL.registerComponent('zesty-banner', {
         }
 
         let image = activeBanner.data.image;
-        image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseIPFS(image);
+        image = image.match(/^.+\.(png|jpe?g)/i) ? image : parseProtocol(image);
 
         return WL.textures.load(image, '').then(texture => {
             activeBanner.texture = texture;


### PR DESCRIPTION
Buyer campaigns now also follow the same uri specifications as zesty NFTs. To look out for `ipfs://`,`ar://`, and `http(s)://` protocols