### PR TITLE
[web] Expose target url through `data-url` attr

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Zesty Web</title>
     <meta name="description" content="Test HTML for Zesty">
-    <script src="dist/zesty-web.js"></script>
+    <script src="dist/zesty-web-sdk.js"></script>
     <!-- <script src="https://lib.zesty.market/zesty-web.js"></script> -->
   </head>
   <body>

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -53,6 +53,7 @@ class Zesty extends HTMLElement {
             img.style.width = width;
             img.style.height = height;
             img.setAttribute('crossorigin', '');
+            img.setAttribute('data-url', url)
             img.addEventListener('click', e => {
                 e.preventDefault();
                 window.open(url, '_blank');


### PR DESCRIPTION
Allows user of SDK to access the target url.

<img width="876" alt="image" src="https://user-images.githubusercontent.com/71227790/133836824-253d8a43-68d6-4342-8144-3cbe96f6b0d4.png">
